### PR TITLE
fix: qualified symbol func should respect overrides

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ file.
  {:group-id wing
   :github   "teknql/wing"
   :projects
-    {core      {:desc   "Extensions to the standard library"
+  {core      {:desc   "Extensions to the standard library"
               :target :jar
               :deps   [org.clojure/core.match
                        slingshot

--- a/src/pablo/config.clj
+++ b/src/pablo/config.clj
@@ -22,9 +22,9 @@
   ([deps-edn] (qualified-symbol deps-edn {}))
   ([deps-edn {:keys [artifact-id group-id]}]
    (let [cfg (config deps-edn)]
-     (-> (str (:or group-id (:group-id cfg))
+     (-> (str (or group-id (:group-id cfg))
               "/"
-              (:or artifact-id (:artifact-id cfg)))
+              (or artifact-id (:artifact-id cfg)))
          (symbol)))))
 
 

--- a/test/pablo/config_test.clj
+++ b/test/pablo/config_test.clj
@@ -1,0 +1,17 @@
+(ns pablo.config-test
+  (:require [pablo.config :as sut]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest qualified-symbol-test
+  (testing "extracts the qualified symbol"
+    (is (= 'teknql/sample
+           (sut/qualified-symbol
+            {sut/key
+             {:artifact-id "sample" :group-id "teknql"}}))))
+
+  (testing "respects overrides"
+    (is (= 'my-group/override
+           (sut/qualified-symbol
+            {sut/key
+             {:artifact-id "sample" :group-id "teknql"}}
+            {:artifact-id "override" :group-id "my-group"})))))


### PR DESCRIPTION
Fixes a small typo in the config namespace, and adds a unit test to prevent regressions