### PR TITLE
fix: support multi-part group-ids

### DIFF
--- a/src/pablo/core.clj
+++ b/src/pablo/core.clj
@@ -16,7 +16,7 @@
     (-> "deps.edn" fs/file slurp read-string)))
 
 (defn- default-opts
-  "Extens opts with some defaults"
+  "Extends opts with some defaults"
   [opts]
   (-> opts
       (update :version (fnil identity (version/from-git)))
@@ -25,7 +25,7 @@
 (defn- run-on-projects
   "Higher order function which calls `f` with a project symbol and its
   `deps.edn` for each project. In a normal repo, runs on the root. For a mono-repo
-  uses the project option, or runs on all projects if its `nil`."
+  uses the `:project` option, or runs on all projects if it's `nil`."
   [opts tgt-keyword f]
   (let [deps-edn (read-deps-edn)
         opts     (default-opts opts)]
@@ -77,7 +77,7 @@
   "Installs a JAR library.
 
   Takes the following options:
-  `:project` - the project selector for a mono-repo. If not set runs on all projects.
+  `:project` - the project selector for a mono-repo. If not set, runs on all projects.
   `:target-dir` - The target directory to source things from.
   `:jar-path` - explicit path to a JAR. Otherwise computed via artifact ID, group ID, and version
   `:version` - explicit version override, otherwise set via git tags
@@ -131,7 +131,7 @@
 (defn publish!
   "Publishes a build artifact to a maven repository.
 
-  Takes the followiong options:
+  Takes the following options:
 
   `:project` - the project to publish (if a monorepo)
   `:target-dir` - The target directory to source things from.

--- a/src/pablo/mono.clj
+++ b/src/pablo/mono.clj
@@ -5,7 +5,8 @@
             [clojure.java.io :as io]
             [pablo.utils :as utils]
             [pablo.config :as cfg]
-            [pablo.pom :as pom]))
+            [pablo.pom :as pom]
+            [clojure.string :as string]))
 
 (defn projects
   "Returns a list of project symbols for the provided mono-repo"
@@ -22,8 +23,9 @@
         project-cfg (some-> cfg :projects project-sym)]
     (if-some [explicit-files (:files project-cfg)]
       explicit-files
-      (let [group-id   (or (:group-id project-cfg)
-                           (:group-id cfg))
+      (let [group-id   (-> (or (:group-id project-cfg)
+                               (:group-id cfg))
+                          (string/replace "-" "_"))
             auto-paths (->> (for [path   (:paths deps-edn)
                                   suffix [".clj" "/"]]
                               (utils/path-join fs/*cwd* path group-id (str project-sym suffix)))

--- a/test/pablo/mono_test.clj
+++ b/test/pablo/mono_test.clj
@@ -38,4 +38,12 @@
         (is (= #{(str path "/src/sample/core.clj")
                  (str path "/test/sample/core.clj")
                  (str path "/test/sample/core")}
-               (sut/project-files base-deps 'core)))))))
+               (sut/project-files base-deps 'core)))))
+
+    (testing "auto-resolution for hyphenated project symbol"
+      (with-temp-dir
+        [path ["/src/my_project/core.clj"]]
+        (is (= #{(str path "/src/my_project/core.clj")}
+               (sut/project-files
+                (assoc-in base-deps [:pablo/config :group-id] 'my-project)
+                'core)))))))


### PR DESCRIPTION
Projects are sometimes hyphenated, but files underscored. This fix accounts
for that in the mono/project-files function, and adds a unit test to prove
it.